### PR TITLE
Cleanup vm domain and xml files

### DIFF
--- a/start-virt.sh
+++ b/start-virt.sh
@@ -78,9 +78,7 @@ process_args() {
     fi
 
     if [[ -f ${GUEST_ROOTDIR}/${GUEST_NAME}.xml ]]; then
-        echo "Error: Guest XML ${GUEST_ROOTDIR}/${GUEST_NAME}.xml already exist."
-        echo "Error: you can delete the old one via 'rm ${GUEST_ROOTDIR}/${GUEST_NAME}.xml'"
-        exit 1
+	rm -rf  "${GUEST_ROOTDIR}/${GUEST_NAME}.xml" || true
     fi
 
     if [[ ! -f ${TEMPLATE} ]]; then

--- a/start-virt.sh
+++ b/start-virt.sh
@@ -68,6 +68,13 @@ process_args() {
         exit 1
     fi
 
+    # If the domain exists for a shutdown VM, it is safe to delete it.
+    # This will also allow the VM to be created later without erroring out.
+    if virsh list  --state-shutoff | grep -q "tdx-guest "; then
+        echo ">Clean up domain for previously shutdown guest"
+	virsh undefine "${GUEST_NAME}" || true
+    fi
+
     if [[ ${FORCE} == "true" ]]; then
         echo "> Clean up the old guest... "
         virsh destroy "${GUEST_NAME}" || true


### PR DESCRIPTION
If the xml file already exists, its best to try and delete it rather
than asking the user to do so. Its safe to do so since the default
location for the xml is in the /tmp directory.

The script will complain while starting a VM if the domain already
exists. While we do not want to delete a VM that is running, it is safe
to delete the domain for a shutdown VM.
